### PR TITLE
Change query method name in API notebook

### DIFF
--- a/notebooks/download_from_api.ipynb
+++ b/notebooks/download_from_api.ipynb
@@ -286,7 +286,7 @@
    "source": [
     "from mp_api import MPRester\n",
     "with MPRester(API_KEY) as mpr:\n",
-    "    hexagonal_materials = mpr.query(crystal_system=\"Hexagonal\", is_stable=True, fields=[\"material_id\"])"
+    "    hexagonal_materials = mpr.summary.search(crystal_system=\"Hexagonal\", is_stable=True, fields=[\"material_id\"])"
    ]
   },
   {


### PR DESCRIPTION
Updated the `MPRester.query` method reference to `MPRester.summary.search` to be commensurate with the latest API client changes.