### PR TITLE
Update `MPRester` import and add `has_props` to query in download notebook

### DIFF
--- a/notebooks/download_from_api.ipynb
+++ b/notebooks/download_from_api.ipynb
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mp_api import MPRester\n",
+    "from mp_api.client import MPRester\n",
     "with MPRester(API_KEY) as mpr:\n",
     "    chgcar = mpr.get_charge_density_from_material_id(\"mp-149\")\n",
     "type(chgcar)"
@@ -137,9 +137,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from mp_api import MPRester\n",
+    "from mp_api.client import MPRester\n",
+    "from emmet.core.summary import HasProps\n",
+    "\n",
     "with MPRester(API_KEY) as mpr:\n",
-    "    hexagonal_materials = mpr.summary.search(crystal_system=\"Hexagonal\", is_stable=True, fields=[\"material_id\"])"
+    "    hexagonal_materials = mpr.summary.search(crystal_system=\"Hexagonal\", \n",
+    "                                             is_stable=True,\n",
+    "                                             has_props=[HasProps.charge_density], \n",
+    "                                             fields=[\"material_id\"])"
    ]
   },
   {


### PR DESCRIPTION
- `from mp_api import MPRester` -> `from mp_api.client import MPRester`.
-  `has_props=[HasProps.charge_density]` added to general query to ensure only materials with charge density data are returned.