### PR TITLE
Fix `python = 3.12` incompatibility

### DIFF
--- a/src/pyrho/__init__.py
+++ b/src/pyrho/__init__.py
@@ -4,7 +4,7 @@ __author__ = """Jimmy Shen"""
 __email__ = "jmmshn@gmail.com"
 
 
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.resources import DistributionNotFound, get_distribution
 
 try:
     __version__ = get_distribution(__name__).version

--- a/src/pyrho/__init__.py
+++ b/src/pyrho/__init__.py
@@ -3,10 +3,9 @@
 __author__ = """Jimmy Shen"""
 __email__ = "jmmshn@gmail.com"
 
-
-from importlib.resources import DistributionNotFound, get_distribution
+from importlib.metadata import version, PackageNotFoundError
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"

--- a/src/pyrho/__init__.py
+++ b/src/pyrho/__init__.py
@@ -3,7 +3,7 @@
 __author__ = """Jimmy Shen"""
 __email__ = "jmmshn@gmail.com"
 
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)


### PR DESCRIPTION
Small fix to allow `python=3.12` compatibility, as `pkg_resources` has now been fully deprecated:
https://github.com/mu-editor/mu/issues/2485

## Contributor Checklist

- [x] I have broken down my PR scope into the following TODO tasks
   -  [x] task 1
   -  [x] task 2
- [x] I have run the tests locally and they passed.
- [x] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR
