### PR TITLE
Refactor to only depend on `pymatgen-core`

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.11", "3.12", "3.13"]
 
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 ]
 authors = [{name = "Jimmy-Xuan Shen", email = "jmmshn@gmail.com"}]
 dependencies = [
-  'pymatgen>=2023.9.21',
+  'pymatgen-core>=2026.4.7',
 ]
 
 description = "Tools for re-griding periodic volumetric quantum chemistry data for machine-learning purposes."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,9 +4,7 @@ requires = ["setuptools >= 60", "setuptools-scm>=8.0", "wheel"]
 
 [project]
 classifiers = [
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python",
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Information Technology",
@@ -25,7 +23,7 @@ keywords = ["machine-learning", "dft", "vasp", "volumetric", "pymatgen"]
 license = {text = "modified BSD"}
 name = "mp-pyrho"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 
 [tool.setuptools_scm]
 

--- a/src/pyrho/charge_density.py
+++ b/src/pyrho/charge_density.py
@@ -11,7 +11,7 @@ import numpy as np
 import numpy.typing as npt
 from monty.dev import deprecated
 from monty.json import MSONable
-from pymatgen.analysis.structure_matcher import ElementComparator, StructureMatcher
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core.lattice import Lattice
 from pymatgen.io.vasp import Chgcar, Poscar, VolumetricData
 

--- a/src/pyrho/charge_density.py
+++ b/src/pyrho/charge_density.py
@@ -11,8 +11,8 @@ import numpy as np
 import numpy.typing as npt
 from monty.dev import deprecated
 from monty.json import MSONable
-from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.core.lattice import Lattice
+from pymatgen.core.structure_matcher import ElementComparator, StructureMatcher
 from pymatgen.io.vasp import Chgcar, Poscar, VolumetricData
 
 from pyrho.pgrid import PGrid


### PR DESCRIPTION
Minor refactor so that `pyrho` only requires `pymatgen-core` and not the full `pymatgen` package.

## Contributor Checklist

- [x] I have run the tests locally and they passed.
~~- [ ] I have added tests, or extended existing tests, to cover any new features or bugs fixed in this PR~~
